### PR TITLE
Change workflow to delete images after building (close #124)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,10 +20,15 @@ jobs:
             # find the build.sh scripts and execute them
             echo "Running all build.sh scripts in repo"
             path=$(pwd)
-            for f in $(find . -iname 'build.sh')
+            for f in $(find . -iname 'build.sh' | sort)
             do
               echo "Running $f"
               (cd $(dirname $f) && ./build.sh && cd $path) || (echo $f "Failed" && exit 1)
               echo "$f completed"
+              echo "Cleaning up docker images"
+              docker images
+              docker rmi $(docker images -a -q)
+              docker system prune -a -f
+              docker images
             done
             echo "Done running build.sh scripts"


### PR DESCRIPTION
Removes all docker images after running each `build.sh`

Note this is a 'big hammer' approach, eventually I'd prefer we only build containers in the folders that changed, this would speed up build times and remove the need for this change

Closes #124 