### PR TITLE
Update version of checkout action in CI scripts. Close #76.

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Run build script - ${{ matrix.script }}
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,5 +11,5 @@ jobs:
     name: Space ROS Commit Message Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: space-ros/check-commit-message-action@main


### PR DESCRIPTION
The version of the checkout action is outdated. The demos CI jobs use versions 3 and 4, although version 6 has already been released. To keep Space ROS and our support infrastructure working with newer versions of dependencies, these actions should be updated.

This commit updates the version of the checkout action in all actions that pin a specific version.