### PR TITLE
Bump pinned containers from jazzy-2026.01.0 to jazzy-2026.04.0 (#142)

### DIFF
--- a/canadarm2/Dockerfile
+++ b/canadarm2/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/space-ros:jazzy-2026.01.0
+FROM osrf/space-ros:jazzy-2026.04.0
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 ENV ROS_DISTRO=jazzy

--- a/curiosity_rover/Dockerfile
+++ b/curiosity_rover/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/space-ros:jazzy-2026.01.0
+FROM osrf/space-ros:jazzy-2026.04.0
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 ENV ROS_DISTRO=jazzy

--- a/nav2_demo/Dockerfile
+++ b/nav2_demo/Dockerfile
@@ -19,7 +19,7 @@
 #   VCS_REF     - The git revision of the Space ROS source code (no default value).
 #   VERSION     - The version of Space ROS (default: "preview")
 
-FROM osrf/space-ros-nav2:jazzy-2026.01.0
+FROM osrf/space-ros-nav2:jazzy-2026.04.0
 
 # Define arguments used in the metadata definition
 ARG VCS_REF

--- a/racs2_demos_on_spaceros/Dockerfile.RACS2
+++ b/racs2_demos_on_spaceros/Dockerfile.RACS2
@@ -1,4 +1,4 @@
-FROM osrf/space-ros:jazzy-2026.01.0
+FROM osrf/space-ros:jazzy-2026.04.0
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp 
 ENV ROS_DISTRO=jazzy

--- a/space_robots/Dockerfile
+++ b/space_robots/Dockerfile
@@ -19,7 +19,7 @@
 #   VCS_REF     - The git revision of the Space ROS source code (no default value).
 #   VERSION     - The version of Space ROS (default: "preview")
 
-FROM osrf/space-ros-moveit2:jazzy-2026.01.0
+FROM osrf/space-ros-moveit2:jazzy-2026.04.0
 
 # Define arguments used in the metadata definition
 ARG VCS_REF


### PR DESCRIPTION
Both the main docker image and stack images must be pushed to dockerhub before this can go in.