### PR TITLE
`lunar_pole_exploration_rover`: Remove unused dependencies (#148)

### DIFF
--- a/lunar_pole_exploration_rover/demo-pkgs.txt
+++ b/lunar_pole_exploration_rover/demo-pkgs.txt
@@ -2,13 +2,10 @@ angles
 backward_ros
 control_msgs
 ros2_control
-warehouse_ros
 xacro
 yaml_cpp_vendor
 python_qt_binding
 control_toolbox
-ros_warehouse
-mongo
 ackermann_msgs
 rviz_common
 image_transport

--- a/lunar_pole_exploration_rover/demo_manual_pkgs.repos
+++ b/lunar_pole_exploration_rover/demo_manual_pkgs.repos
@@ -31,10 +31,6 @@ repositories:
     type: git
     url: https://github.com/gazebosim/ros_gz.git
     version: humble
-  ros-humble-warehouse-ros-mongo:
-    type: git
-    url: https://github.com/ros-planning/warehouse_ros_mongo.git
-    version: ros2
   vision_msgs:
     type: git
     url: https://github.com/ros-perception/vision_msgs.git


### PR DESCRIPTION
Fixes #148.

`warehouse_ros` is listed unpinned in `demo-pkgs.txt`, so `rosinstall_generator --upstream --rosdistro humble` follows whatever humble's rosdistro currently points at. Version 2.0.7 switched its tf2 includes from `.h` to `.hpp`, which the `osrf/space-ros:humble-2024.10.0` base image does not provide. See #148 for the full timeline.

Nothing in this demo uses warehouse_ros — it is absent from `package.xml` and unreferenced by the launch file, nodes, config, worlds and README — so this removes it rather than pinning a version that would need maintaining. `ros_warehouse` and `mongo` go with it; both are unreleased in humble and were already being discarded by the generator (*"The following unreleased packages/stacks will be ignored: --, mongo, ros_warehouse"*).

### Verification

Built locally from this branch: **99 packages finished, 0 failed, 0 aborted.**

Caveat on the build host: it is aarch64, so the `osrf/space-ros:humble-2024.10.0` base image was rebuilt natively from the `humble-2024.10.0` tag of `space-ros/space-ros` using its own Earthfile (all 62 repos resolved to the same SHAs as the published image). One extra apt source was needed locally because `packages.ros.org` ships `libignition-sensors6` 6.8.0 for arm64 while `libignition-gazebo6` 6.18.0 requires >= 6.8.1 — that is an arm64-only workaround and is deliberately **not** part of this change. Neither adjustment touches the packages involved here.

### Scope

Intentionally minimal, so it can be reviewed and merged quickly to unblock CI. The demo also builds a number of other packages it never uses — the whole RViz stack, rqt tools, and upstream example packages — but removing those is a separate change and will be proposed independently.
