### PR TITLE
`lunar_pole_exploration_rover`: Drop unused RViz, rqt and example packages (#153)

### DIFF
--- a/lunar_pole_exploration_rover/Dockerfile
+++ b/lunar_pole_exploration_rover/Dockerfile
@@ -126,6 +126,28 @@ RUN vcs import src < /tmp/demo_manual_pkgs.repos \
   && vcs custom ${SPACEROS_DIR}/src --args lfs pull \
   && /bin/bash -c 'source "${SPACEROS_DIR}/install/setup.bash"'
 
+# Drop packages that arrive with the repos above but that this demo never uses.
+# They are not free: vision_msgs_rviz_plugins does find_package(rviz_common), which
+# pulls the whole RViz stack (rviz_ogre_vendor and friends) into the source build,
+# and the upstream demo packages make rosdep apt-install ~200 ros-humble-* debs into
+# /opt/ros/humble, which nothing ever sources. The rqt tools could not run here in
+# any case: rqt_gui is not in the workspace, only as one of those unsourced debs.
+# The list is dependency-closed - ros_gz and ros_ign are metapackages that exec_depend
+# on the demo packages, and gz_ros2_control_tests tests them, so leaving any of those
+# behind just makes rosdep try to apt-install what was removed.
+RUN set -e; for pkg in \
+      vision_msgs/vision_msgs_rviz_plugins \
+      ros_gz/ros_gz \
+      ros_gz/ros_ign \
+      ros_gz/ros_gz_sim_demos \
+      ros_gz/ros_ign_gazebo_demos \
+      gz_ros2_control/gz_ros2_control_demos \
+      gz_ros2_control/ign_ros2_control_demos \
+      gz_ros2_control/gz_ros2_control_tests \
+      ros2_control/rqt_controller_manager \
+      ros2_controllers/rqt_joint_trajectory_controller \
+    ; do touch "src/$pkg/COLCON_IGNORE"; done
+
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   sudo apt-get update -y \

--- a/lunar_pole_exploration_rover/demo-pkgs.txt
+++ b/lunar_pole_exploration_rover/demo-pkgs.txt
@@ -4,14 +4,6 @@ control_msgs
 ros2_control
 xacro
 yaml_cpp_vendor
-python_qt_binding
 control_toolbox
 ackermann_msgs
-rviz_common
 image_transport
-interactive_markers
-laser_geometry
-map_msgs
-point_cloud_transport
-resource_retriever
-visualization_msgs

--- a/lunar_pole_exploration_rover/demo_manual_pkgs.repos
+++ b/lunar_pole_exploration_rover/demo_manual_pkgs.repos
@@ -7,10 +7,6 @@ repositories:
     type: git
     url: https://github.com/space-ros/simulation.git
     version: main
-  qt_gui_core:
-    type: git
-    url: https://github.com/ros-visualization/qt_gui_core.git
-    version: humble
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Fixes #153.

Two commits, in this order deliberately — the `COLCON_IGNORE` list is a prerequisite for the package-list removals, not a consequence of them. Removing `rviz_common` first would break the build, because `vision_msgs_rviz_plugins` still does `find_package(rviz_common REQUIRED)`.

1. **Skip unused RViz, rqt and example packages** — marks ten packages that ship inside repos the demo genuinely needs (`vision_msgs`, `ros_gz`, `gz_ros2_control`, `ros2_control`, `ros2_controllers`) with `COLCON_IGNORE`. `vcs` clones whole repos, so these cannot be dropped from the list files.
2. **Drop unused dependencies from package lists** — removes eight entries from `demo-pkgs.txt` and `qt_gui_core` from `demo_manual_pkgs.repos`, now that nothing needs RViz.

See #153 for the full breakdown of which package comes from where.

### Effect

| | before | after |
|---|---|---|
| packages built | 99 | 67 |
| `ros-humble-*` debs installed | 195 | 142 |
| image size | 7.43 GB | 6.92 GB |

### Two things a reviewer should know before trimming the ignore list

**It is dependency-closed.** `ros_gz` and `ros_ign` are metapackages that `exec_depend` on the demo packages, and `gz_ros2_control_tests` tests them. Leaving any of those three behind makes `rosdep` try to `apt-get install ros-humble-ros-gz-sim-demos`, which does not exist as a deb, and the build fails at the rosdep step. I hit exactly that on a first attempt.

**`colcon build --packages-ignore` is not a substitute.** `rosdep install --from-paths src` crawls the source tree before colcon runs, so it would still apt-install every one of those debs. `COLCON_IGNORE` is honoured by both tools, which is what removes the apt side too.

### Verification

Built from this branch: **67 packages finished, 0 failed, 0 aborted.**

Runtime check on the resulting image: launch description builds (which exercises xacro on the rover URDF and every package and executable reference), `ros2 control` CLI works, all four launch-file executables resolve (`ros_gz_bridge/parameter_bridge`, `ros_ign_gazebo/create`, `ros_ign_image/image_bridge`, `robot_state_publisher`), all four demo nodes start, and all six services documented in the README are advertised.

Confirmed absent from the build: `rviz_ogre_vendor`, `rviz_common`, `python_qt_binding`, `qt_gui`, `vision_msgs_rviz_plugins`.

Caveat on the build host: it is aarch64, so `osrf/space-ros:humble-2024.10.0` was rebuilt natively from the `humble-2024.10.0` tag of `space-ros/space-ros` using its own Earthfile — all 62 repos resolved to the same SHAs as the published image. One extra apt source was needed locally because `packages.ros.org` ships `libignition-sensors6` 6.8.0 for arm64 while `libignition-gazebo6` 6.18.0 requires >= 6.8.1; that is an arm64-only workaround and is **not** part of this change.
